### PR TITLE
OJ-1492: Remove Experian IIQ config from Toy

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -124,30 +124,6 @@ Mappings:
       integration: 1024
       production: 2048
 
-  IIQAPIDatabaseModeMapping:
-    Environment:
-      dev: Static
-      build: Static
-      staging: Static
-      integration: Static
-      production: Normal
-
-  IIQAPIStrategyMapping:
-    Environment:
-      dev: 3 out of 4 prioritised
-      build: 3 out of 4 prioritised
-      staging: 3 out of 4 prioritised
-      integration: 3 out of 4 prioritised
-      production: 3 out of 4 prioritised
-
-  IIQOperatorIdMapping:
-    Environment:
-      dev: GDSCABINETUIIQ01U
-      build: GDSCABINETUIIQ01U
-      staging: GDSCABINETUIIQ01U
-      integration: GDSCABINETUIIQ01U
-      production: GDSCABINETUIIQ01U
-
   # Only numeric values should be assigned here
   MaxJwtTtlMapping:
     Environment:
@@ -605,31 +581,6 @@ Resources:
       Type: String
       Value: !FindInMap [JwtTtlUnitMapping, Environment, !Ref Environment]
       Description: The unit for the time-to-live for an JWT e.g. (MONTHS)
-
-  IIQAPIDatabaseModeParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/IIQDatabaseMode"
-      Type: String
-      Value:
-        !FindInMap [IIQAPIDatabaseModeMapping, Environment, !Ref "Environment"]
-      Description: "one of: S or Static, A or Aged, N or Normal (Live)"
-
-  IIQAPIStrategyParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/IIQStrategy"
-      Type: String
-      Value: !FindInMap [IIQAPIStrategyMapping, Environment, !Ref "Environment"]
-      Description: Strategy to be used for Experian Toy Questions. Example - 3 of 4
-
-  IIQOperatorIdParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/IIQOperatorId"
-      Type: String
-      Value: !FindInMap [IIQOperatorIdMapping, Environment, !Ref "Environment"]
-      Description: Unique operator id provided by Experian to GDS
 
   IPVCoreStubAuthenticationAlgParameter:
     Condition: IsStubEnvironment


### PR DESCRIPTION
## Proposed changes

This just a cleanup PR, before I do the actual thing https://govukverify.atlassian.net/browse/OJ-1492

Remove Experian IIQ config from Toy

### What changed

It is not needed here

### Why did it change

To remove clutter
