### PR TITLE
OJ-1492: add create authorization code middleware

### DIFF
--- a/lambdas/middlewares/session/create-authorization-code-middleware.ts
+++ b/lambdas/middlewares/session/create-authorization-code-middleware.ts
@@ -1,0 +1,56 @@
+import { DynamoDBDocument, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { MiddlewareObj, Request } from "@middy/core";
+import { ConfigService } from "../../common/config/config-service";
+import { logger } from "../../common/utils/power-tool";
+import { CommonConfigKey } from "../../types/config-keys";
+import { randomUUID } from "crypto";
+
+const defaults = {};
+
+const createAuthorizationCodeMiddleware = (opts: {
+  configService: ConfigService;
+  dynamoDbClient: DynamoDBDocument;
+}): MiddlewareObj => {
+  const options = { ...defaults, ...opts };
+  const after = async (request: Request) => {
+    const body = request.event.body;
+    if (body.status !== "Authenticated") return await request.event;
+
+    logger.info("Updating toy in dynamoDB table with authorizationCode");
+    const authorizationCode = randomUUID();
+    await options.dynamoDbClient.send(
+      new UpdateCommand({
+        TableName: options.configService.getConfigEntry(
+          CommonConfigKey.SESSION_TABLE_NAME
+        ),
+        Key: { sessionId: body.sessionId },
+        UpdateExpression:
+          "SET authorizationCode=:authCode, authorizationCodeExpiryDate=:authCodeExpiry",
+        ExpressionAttributeValues: {
+          ":authCode": authorizationCode,
+          ":authCodeExpiry": getAuthorizationCodeExpirationEpoch(),
+        },
+      })
+    );
+    await request.event;
+  };
+
+  return {
+    after,
+  };
+};
+
+function getAuthorizationCodeExpirationEpoch() {
+  const DEFAULT_AUTHORIZATION_CODE_TTL_IN_SECS = 600;
+  const envAuthCodeTtl =
+    parseInt(process.env.AUTHORIZATION_CODE_TTL as string, 10) ||
+    DEFAULT_AUTHORIZATION_CODE_TTL_IN_SECS;
+  const authorizationCodeTtlInMillis = envAuthCodeTtl * 1000;
+  const currentTimestampInMillis = Date.now();
+  const expirationTimestampInSeconds = Math.floor(
+    (currentTimestampInMillis + authorizationCodeTtlInMillis) / 1000
+  );
+  return expirationTimestampInSeconds;
+}
+
+export default createAuthorizationCodeMiddleware;

--- a/tests/middleware/create-authorization-code-middleware.test.ts
+++ b/tests/middleware/create-authorization-code-middleware.test.ts
@@ -1,0 +1,169 @@
+import { DynamoDBDocument, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { ConfigService } from "../../lambdas/common/config/config-service";
+import { Request } from "@middy/core";
+import createAuthorizationCodeMiddleware from "../../lambdas/middlewares/session/create-authorization-code-middleware";
+
+jest.mock("@aws-sdk/lib-dynamodb", () => ({
+  __esModule: true,
+  ...jest.requireActual("@aws-sdk/lib-dynamodb"),
+  UpdateCommand: jest.fn(),
+}));
+jest.mock("crypto", () => ({
+  ...jest.requireActual("crypto"),
+  randomUUID: () => "d7c05e44-37e6-4ed4-b6d3-01af51a95f84",
+}));
+describe("create-authorization-code-middleware.ts", () => {
+  let dynamoDbClient: jest.MockedObjectDeep<typeof DynamoDBDocument>;
+  let updateCommand: jest.MockedObjectDeep<typeof UpdateCommand>;
+  let configService: jest.MockedObjectDeep<typeof ConfigService>;
+
+  const expiryDate = Math.floor(Date.now() / 1000);
+  const aRandomUUID = "d7c05e44-37e6-4ed4-b6d3-01af51a95f84";
+  const sessionId = "6b0f3490-db8b-4803-967d-39d77a2ece21";
+
+  beforeEach(() => {
+    dynamoDbClient = jest.mocked(DynamoDBDocument);
+    updateCommand = jest.mocked(UpdateCommand);
+    configService = jest.mocked(ConfigService);
+
+    jest
+      .spyOn(configService.prototype, "getConfigEntry")
+      .mockReturnValue("sessionTable");
+  });
+  afterEach(() => jest.clearAllMocks());
+
+  describe("event containing status of authenticated", () => {
+    const mockEvent = {
+      event: {
+        body: {
+          sessionId,
+          expiryDate,
+          status: "Authenticated",
+        },
+      },
+    };
+
+    it("should update the session item with authCode", async () => {
+      const dbSpy = jest
+        .spyOn(dynamoDbClient.prototype, "send")
+        .mockImplementation();
+      const middleware = createAuthorizationCodeMiddleware({
+        configService: configService.prototype,
+        dynamoDbClient: dynamoDbClient.prototype,
+      });
+      if (middleware?.after) {
+        await middleware.after(mockEvent as Request<unknown>);
+        expect(dbSpy).toHaveBeenCalledTimes(1);
+        expect(updateCommand).toHaveBeenCalledWith({
+          TableName: "sessionTable",
+          Key: { sessionId: "6b0f3490-db8b-4803-967d-39d77a2ece21" },
+          UpdateExpression:
+            "SET authorizationCode=:authCode, authorizationCodeExpiryDate=:authCodeExpiry",
+          ExpressionAttributeValues: {
+            ":authCode": aRandomUUID,
+            ":authCodeExpiry": expect.any(Number),
+          },
+        });
+      }
+      expect.assertions(2);
+    });
+
+    it("should update sessionItem using default ttl for authCode expiry", async () => {
+      const dbSpy = jest
+        .spyOn(dynamoDbClient.prototype, "send")
+        .mockImplementation();
+      const timestampInMillisOf26Jun20230906 = 1687766800499;
+      const expectedExpiryIn10minsTime = 1687767400;
+      jest
+        .spyOn(Date, "now")
+        .mockReturnValueOnce(timestampInMillisOf26Jun20230906);
+      const middleware = createAuthorizationCodeMiddleware({
+        configService: configService.prototype,
+        dynamoDbClient: dynamoDbClient.prototype,
+      });
+      if (middleware?.after) {
+        await middleware.after(mockEvent as Request<unknown>);
+        expect(dbSpy).toHaveBeenCalledTimes(1);
+        expect(updateCommand).toHaveBeenCalledWith({
+          TableName: "sessionTable",
+          Key: { sessionId: "6b0f3490-db8b-4803-967d-39d77a2ece21" },
+          UpdateExpression:
+            "SET authorizationCode=:authCode, authorizationCodeExpiryDate=:authCodeExpiry",
+          ExpressionAttributeValues: {
+            ":authCode": aRandomUUID,
+            ":authCodeExpiry": expectedExpiryIn10minsTime,
+          },
+        });
+      }
+      expect.assertions(2);
+    });
+    it("should update sessionItem using env AUTHORIZATION_CODE_TTL for authCode expiry", async () => {
+      process.env = {
+        ...process.env,
+        AUTHORIZATION_CODE_TTL: "20",
+      };
+      const dbSpy = jest
+        .spyOn(dynamoDbClient.prototype, "send")
+        .mockImplementation();
+      const timestampInMillisOf26Jun20230906 = 1687766800499;
+      const expectedExpiryIn20minsTime = 1687766820;
+      jest
+        .spyOn(Date, "now")
+        .mockReturnValueOnce(timestampInMillisOf26Jun20230906);
+      const middleware = createAuthorizationCodeMiddleware({
+        configService: configService.prototype,
+        dynamoDbClient: dynamoDbClient.prototype,
+      });
+      if (middleware?.after) {
+        await middleware.after(mockEvent as Request<unknown>);
+        expect(dbSpy).toHaveBeenCalledTimes(1);
+        expect(updateCommand).toHaveBeenCalledWith({
+          TableName: "sessionTable",
+          Key: { sessionId: "6b0f3490-db8b-4803-967d-39d77a2ece21" },
+          UpdateExpression:
+            "SET authorizationCode=:authCode, authorizationCodeExpiryDate=:authCodeExpiry",
+          ExpressionAttributeValues: {
+            ":authCode": aRandomUUID,
+            ":authCodeExpiry": expectedExpiryIn20minsTime,
+          },
+        });
+      }
+      expect.assertions(2);
+    });
+  });
+  describe("event containing status of Not Authenticated", () => {
+    const mockEvent = {
+      event: {
+        body: {
+          sessionId,
+          expiryDate,
+          status: "Not Authenticated",
+        },
+      },
+    };
+    it("should upload the toy item to dynamo", async () => {
+      const dbSpy = jest
+        .spyOn(dynamoDbClient.prototype, "send")
+        .mockImplementation();
+      const middleware = createAuthorizationCodeMiddleware({
+        configService: configService.prototype,
+        dynamoDbClient: dynamoDbClient.prototype,
+      });
+      if (middleware?.after) {
+        await middleware.after(mockEvent as Request<unknown>);
+        expect(dbSpy).not.toHaveBeenCalledTimes(1);
+        expect(updateCommand).not.toHaveBeenCalledWith({
+          TableName: "sessionTable",
+          Key: { sessionId: "6b0f3490-db8b-4803-967d-39d77a2ece21" },
+          UpdateExpression:
+            "SET authorizationCode=:authCode, authorizationCodeExpiryDate=:authCodeExpiry",
+          ExpressionAttributeValues: {
+            ":authCode": aRandomUUID,
+            ":authCodeExpiry": expect.any(Number),
+          },
+        });
+      }
+      expect.assertions(2);
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes

Added create auth code middleware, when a Toy interaction is OK (200) the session Item is updated with an auth code. If not the the update is skipped in the middleware

### What changed

See above

### Why did it change

Need to generate an auth code, which is needed in subsequent request on the token endpoint

### Issue tracking

- [OJ-1492](https://govukverify.atlassian.net/browse/OJ-1492)




[OJ-1492]: https://govukverify.atlassian.net/browse/OJ-1492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ