### PR TITLE
OJ-1492: Add veriable credential builder

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -25,4 +25,5 @@ export default {
   preset: "ts-jest",
   testEnvironment: "node",
   globalSetup: "<rootDir>/dotenv/dotenv-test.js",
+  setupFiles: ["<rootDir>/setEnvVars.js"],
 };

--- a/lambdas/verifiable-credential/types/verifiable-credentials.ts
+++ b/lambdas/verifiable-credential/types/verifiable-credentials.ts
@@ -1,19 +1,20 @@
 export enum ChronoUnit {
-    Seconds = 'seconds',
-    Minutes = 'minutes',
-    Hours = 'hours',
-    Days = 'days',
+  Seconds = "seconds",
+  Minutes = "minutes",
+  Hours = "hours",
+  Days = "days",
 }
 
 export type VerifiableCredential = {
-    jti?: string
-    sub: string;
-    iss: string;
-    exp?: number;
-    vc: {
-      type: string[];
-      credentialSubject: string;
-      "@context"?: undefined | string[];
-      evidence?: undefined | unknown;
-    }
-  }
+  jti?: string;
+  sub: string;
+  iss: string;
+  nbf: number;
+  exp?: number;
+  vc: {
+    type: string[];
+    credentialSubject: string;
+    "@context"?: undefined | string[];
+    evidence?: undefined | unknown;
+  };
+};

--- a/lambdas/verifiable-credential/types/verifiable-credentials.ts
+++ b/lambdas/verifiable-credential/types/verifiable-credentials.ts
@@ -1,0 +1,19 @@
+export enum ChronoUnit {
+    Seconds = 'seconds',
+    Minutes = 'minutes',
+    Hours = 'hours',
+    Days = 'days',
+}
+
+export type VerifiableCredential = {
+    jti?: string
+    sub: string;
+    iss: string;
+    exp?: number;
+    vc: {
+      type: string[];
+      credentialSubject: string;
+      "@context"?: undefined | string[];
+      evidence?: undefined | unknown;
+    }
+  }

--- a/lambdas/verifiable-credential/verifiable-credential-builder.ts
+++ b/lambdas/verifiable-credential/verifiable-credential-builder.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from "crypto";
+import { ChronoUnit, VerifiableCredential } from "./types/verifiable-credentials";
+
+export class VerifiableCredentialBuilder {
+  static ChronoUnit = ChronoUnit;
+
+  private credential: VerifiableCredential = {
+    sub: "",
+    iss: "",
+    vc: {
+      type: [],
+      credentialSubject: "",
+    },
+  } as VerifiableCredential;
+
+  claims() {
+    return this.credential;
+  }
+
+  jti(): VerifiableCredentialBuilder {
+    this.credential.jti = randomUUID();
+    return this;
+  }
+  subject(subject: string): VerifiableCredentialBuilder {
+    if (!subject) throw new Error("The subject must not be null or empty.");
+
+    this.credential.sub = subject;
+    return this;
+  }
+
+  issuer(issuer: string) : VerifiableCredentialBuilder {
+    if (!issuer) throw new Error("The issuer must not be null or empty.");
+
+    this.credential.iss = issuer;
+    return this;
+  }
+
+  timeToLive(ttl: number, unit: ChronoUnit): VerifiableCredentialBuilder {
+    const now = new Date();
+    const expirationTime = new Date(now.getTime() + ttl * this.getUnitMultiplier(unit));
+    this.credential.exp = expirationTime.getTime();
+    return this;
+  }
+
+  verifiableCredentialType(types: Array<string>) : VerifiableCredentialBuilder{
+    if (Array.isArray(types) && !types?.length) throw new Error("The VerifiableCredential type must not be null or empty.");
+
+    this.credential.vc.type = types;
+    return this;
+  }
+
+  verifiableCredentialSubject(subject: string) : VerifiableCredentialBuilder {
+    if (!subject) throw new Error("The VerifiableCredential subject must not be null or empty.");
+
+    this.credential.vc.credentialSubject = subject;
+    return this;
+  }
+
+  verifiableCredentialContext(contexts: string[]) : VerifiableCredentialBuilder {
+    if (!contexts) throw new Error("The VerifiableCredential context must not be null or empty.");
+    
+    this.credential.vc["@context"] = contexts;
+    return this;
+  }
+
+  verifiableCredentialEvidence(evidence: object) : VerifiableCredentialBuilder {
+    if (!evidence) throw new Error("The VerifiableCredential evidence must not be null or empty.");
+
+    this.credential.vc.evidence = evidence;
+    return this;
+  }
+
+  build() {
+    return this.credential;
+  }
+
+  private getUnitMultiplier(unit: string): number {
+    switch (unit) {
+      case ChronoUnit.Seconds:
+        return 1000;
+      case ChronoUnit.Minutes:
+        return 1000 * 60;
+      case ChronoUnit.Hours:
+        return 1000 * 60 * 60;
+      case ChronoUnit.Days:
+        return 1000 * 60 * 60 * 24;
+      default:
+        throw new Error(`Unexpected time-to-live unit encountered: ${unit}`);
+    }
+  }
+}

--- a/lambdas/verifiable-credential/verifiable-credential-builder.ts
+++ b/lambdas/verifiable-credential/verifiable-credential-builder.ts
@@ -1,26 +1,36 @@
 import { randomUUID } from "crypto";
-import { ChronoUnit, VerifiableCredential } from "./types/verifiable-credentials";
+import {
+  ChronoUnit,
+  VerifiableCredential,
+} from "./types/verifiable-credentials";
+import { GetParameterCommand, Parameter, SSMClient } from "@aws-sdk/client-ssm";
 
+export enum ConfigKey {
+  CONTAINS_UNIQUE_ID = "release-flags/vc-contains-unique-id",
+  EXPIRY_REMOVED = "/release-flags/vc-expiry-removed",
+}
+const PARAMETER_PREFIX = process.env.AWS_STACK_NAME || "";
 export class VerifiableCredentialBuilder {
   static ChronoUnit = ChronoUnit;
-
-  private credential: VerifiableCredential = {
-    sub: "",
-    iss: "",
-    vc: {
-      type: [],
-      credentialSubject: "",
-    },
-  } as VerifiableCredential;
+  constructor(
+    private ssmClient: SSMClient,
+    private ttl: number = 0,
+    private ttlUnit: ChronoUnit | undefined = undefined,
+    private credential: VerifiableCredential = {
+      sub: "",
+      iss: "",
+      nbf: 0,
+      vc: {
+        type: [],
+        credentialSubject: "",
+      },
+    } as VerifiableCredential
+  ) {}
 
   claims() {
     return this.credential;
   }
 
-  jti(): VerifiableCredentialBuilder {
-    this.credential.jti = randomUUID();
-    return this;
-  }
   subject(subject: string): VerifiableCredentialBuilder {
     if (!subject) throw new Error("The subject must not be null or empty.");
 
@@ -28,53 +38,91 @@ export class VerifiableCredentialBuilder {
     return this;
   }
 
-  issuer(issuer: string) : VerifiableCredentialBuilder {
+  issuer(issuer: string): VerifiableCredentialBuilder {
     if (!issuer) throw new Error("The issuer must not be null or empty.");
 
     this.credential.iss = issuer;
     return this;
   }
 
-  timeToLive(ttl: number, unit: ChronoUnit): VerifiableCredentialBuilder {
-    const now = new Date();
-    const expirationTime = new Date(now.getTime() + ttl * this.getUnitMultiplier(unit));
-    this.credential.exp = expirationTime.getTime();
+  timeToLive(
+    ttl: number,
+    unit: ChronoUnit | undefined
+  ): VerifiableCredentialBuilder {
+    if (!unit || !Object.values(ChronoUnit).includes(unit)) {
+      throw new Error("ttlUnit must be valid");
+    }
+    if (ttl <= 0) {
+      throw new Error("ttl must be greater than zero");
+    }
+
+    this.ttlUnit = unit;
+    this.ttl = ttl;
     return this;
   }
 
-  verifiableCredentialType(types: Array<string>) : VerifiableCredentialBuilder{
-    if (Array.isArray(types) && !types?.length) throw new Error("The VerifiableCredential type must not be null or empty.");
+  verifiableCredentialType(types: Array<string>): VerifiableCredentialBuilder {
+    if (Array.isArray(types) && !types?.length)
+      throw new Error(
+        "The VerifiableCredential type must not be null or empty."
+      );
 
     this.credential.vc.type = types;
     return this;
   }
 
-  verifiableCredentialSubject(subject: string) : VerifiableCredentialBuilder {
-    if (!subject) throw new Error("The VerifiableCredential subject must not be null or empty.");
+  verifiableCredentialSubject(subject: string): VerifiableCredentialBuilder {
+    if (!subject)
+      throw new Error(
+        "The VerifiableCredential subject must not be null or empty."
+      );
 
     this.credential.vc.credentialSubject = subject;
     return this;
   }
 
-  verifiableCredentialContext(contexts: string[]) : VerifiableCredentialBuilder {
-    if (!contexts) throw new Error("The VerifiableCredential context must not be null or empty.");
-    
+  verifiableCredentialContext(contexts: string[]): VerifiableCredentialBuilder {
+    if (!contexts || !Array.isArray(contexts) || !contexts.length)
+      throw new Error(
+        "The VerifiableCredential context must not be null or empty."
+      );
+
     this.credential.vc["@context"] = contexts;
     return this;
   }
-
-  verifiableCredentialEvidence(evidence: object) : VerifiableCredentialBuilder {
-    if (!evidence) throw new Error("The VerifiableCredential evidence must not be null or empty.");
+  verifiableCredentialEvidence(evidence: object): VerifiableCredentialBuilder {
+    if (!evidence)
+      throw new Error(
+        "The VerifiableCredential evidence must not be null or empty."
+      );
 
     this.credential.vc.evidence = evidence;
     return this;
   }
 
-  build() {
+  async build(): Promise<VerifiableCredential> {
+    this.credential.nbf = Math.floor(new Date().getTime() / 1000);
+    if (
+      await this.isReleaseFlag(
+        this.getParameter.bind(this),
+        ConfigKey.CONTAINS_UNIQUE_ID
+      )
+    ) {
+      this.credential.jti = this.generateUniqueId();
+    }
+    if (
+      !(await this.isReleaseFlag(
+        this.getParameter.bind(this),
+        ConfigKey.EXPIRY_REMOVED
+      ))
+    ) {
+      this.credential.exp =
+        Date.now() + this.ttl * this.getUnitMultiplier(this.ttlUnit);
+    }
     return this.credential;
   }
 
-  private getUnitMultiplier(unit: string): number {
+  private getUnitMultiplier(unit?: string): number {
     switch (unit) {
       case ChronoUnit.Seconds:
         return 1000;
@@ -87,5 +135,32 @@ export class VerifiableCredentialBuilder {
       default:
         throw new Error(`Unexpected time-to-live unit encountered: ${unit}`);
     }
+  }
+  private generateUniqueId(): string {
+    return `urn:uuid:${randomUUID()}`;
+  }
+
+  private async isReleaseFlag(
+    parameterGetter: (arg: string) => Promise<Parameter>,
+    flagParameterPath: string
+  ): Promise<boolean> {
+    return (await parameterGetter(flagParameterPath)).Value === "true";
+  }
+
+  private async getParameter(ssmParamName: string): Promise<Parameter> {
+    const paramName = this.isAnAbsolutePathParameter(ssmParamName)
+      ? ssmParamName
+      : `/${PARAMETER_PREFIX}/${ssmParamName}`;
+    const getParamResult = await this.ssmClient.send(
+      new GetParameterCommand({ Name: paramName })
+    );
+    if (!getParamResult?.Parameter) {
+      throw new Error(`Invalid SSM parameter: ${paramName}`);
+    }
+    return getParamResult.Parameter;
+  }
+
+  private isAnAbsolutePathParameter(ssmParameter: string): boolean {
+    return ssmParameter.startsWith("/");
   }
 }

--- a/setEnvVars.js
+++ b/setEnvVars.js
@@ -1,0 +1,1 @@
+process.env.AWS_STACK_NAME = "di-ipv-cri-toy-api";

--- a/tests/utils/verifiable-credential-builder.test.ts
+++ b/tests/utils/verifiable-credential-builder.test.ts
@@ -1,0 +1,252 @@
+import { ChronoUnit } from "../../lambdas/verifiable-credential/types/verifiable-credentials";
+import {
+  VerifiableCredentialBuilder,
+} from "../../lambdas/verifiable-credential/verifiable-credential-builder";
+import crypto from "crypto";
+describe("verifiable-credential-builder.ts", () => {
+  let builder: VerifiableCredentialBuilder;
+
+  beforeEach(() => {
+    builder = new VerifiableCredentialBuilder();
+  });
+
+  describe("subject", () => {
+    it("should be set to a value supplied", () => {
+      builder.subject("Kenneth Decerqueira");
+
+      expect(builder.claims().sub).toBe(
+        "Kenneth Decerqueira"
+      );
+    });
+
+    it.each(["", null, undefined])("should not be '%s'", (value) => {
+      expect(() => builder.subject(value as unknown as string)).toThrow(
+        "The subject must not be null or empty."
+      );
+    });
+  });
+  describe("issuer", () => {
+    it("should be set to value supplied", () => {
+      builder.issuer("an-issuer-for-toy");
+
+      expect(builder.claims().iss).toBe("an-issuer-for-toy");
+    });
+    it.each(["", null, undefined])("should not be '%s'", (value) => {
+      expect(() => builder.issuer(value as unknown as string)).toThrow(
+        "The issuer must not be null or empty."
+      );
+    });
+  });
+  describe("timeToLive", () => {
+    const twentyOfJune2023InMs = 1687269570000;
+    const thirtySecondsInMs = 30 * 1000;
+    const thirtyMinutesInMs = 30 * 60 * 1000;
+    const thirtyHoursInMs = 30 * 60 * 60 * 1000;
+    const thirtyDaysInMs = 30 * 24 * 60 * 60 * 1000;
+    it.each([
+      [ChronoUnit.Seconds, thirtySecondsInMs],
+      [ChronoUnit.Minutes, thirtyMinutesInMs],
+      [ChronoUnit.Hours, thirtyHoursInMs],
+      [ChronoUnit.Days, thirtyDaysInMs],
+    ])("should set expiration time in '%s'", (timeUnit, ttlDuration) => {
+      jest
+        .spyOn(Date.prototype, "getTime")
+        .mockReturnValueOnce(twentyOfJune2023InMs);
+      const expectedExpirationTime = Math.floor(
+        twentyOfJune2023InMs + ttlDuration
+      );
+      builder.timeToLive(30, timeUnit);
+
+      expect(builder.claims().exp).toEqual(
+        expectedExpirationTime
+      );
+    });
+
+    it("should throw an error for an invalid unit", () => {
+      expect(() =>
+        builder.timeToLive(30, "invalid" as unknown as ChronoUnit)
+      ).toThrow("Unexpected time-to-live unit encountered: invalid");
+    });
+  });
+  describe("verifiableCredentialType", () => {
+    it("should be set to the value supplied", () => {
+      builder.verifiableCredentialType(["VerifiableCredential", "IdentityCheckCredential"]);
+
+      expect(builder.claims().vc.type).toEqual([
+        "VerifiableCredential",
+        "IdentityCheckCredential",
+      ]);
+    });
+    it("should not be '%s'", () => {
+      expect(() =>
+        builder.verifiableCredentialType([])
+      ).toThrow("The VerifiableCredential type must not be null or empty.");
+    });
+  });
+  describe("verifiableCredentialSubject", () => {
+    it("should be set to the value supplied", () => {
+      builder.verifiableCredentialSubject("Kenneth Decerqueira");
+
+      expect(builder.claims().vc.credentialSubject).toEqual(
+        "Kenneth Decerqueira"
+      );
+    });
+    it.each(["", null, undefined])("should not be '%s'", (type) => {
+      expect(() =>
+        builder.verifiableCredentialSubject(type as unknown as string)
+      ).toThrow("The VerifiableCredential subject must not be null or empty.");
+    });
+  });
+  describe("verifiableCredentialContext", () => {
+    let contexts: Array<string>;
+    beforeEach(() => {
+      contexts = ["context1", "context2"];
+    });
+    it("should be set to the value supplied", () => {
+      builder.verifiableCredentialContext(contexts);
+
+      expect(builder.claims().vc["@context"]).toEqual(contexts);
+    });
+    it.each(["", null, undefined])("should not be '%s'", (type) => {
+      expect(() =>
+        builder.verifiableCredentialContext(type as unknown as Array<string>)
+      ).toThrow("The VerifiableCredential context must not be null or empty.");
+    });
+  });
+  describe("verifiableCredentialEvidence", () => {
+    let evidence: object;
+    beforeEach(() => {
+      evidence = new Map([
+        ["evidence-key-1", "evidence-value-1"],
+        ["evidence-key-2", "evidence-value-2"],
+      ]);
+    });
+    it("should be set to the value supplied", () => {
+      builder.verifiableCredentialEvidence(evidence);
+
+      expect(builder.claims().vc.evidence).toEqual(evidence);
+    });
+    it.each(["", null, undefined])("should not be '%s'", (type) => {
+      expect(() =>
+        builder.verifiableCredentialEvidence(type as unknown as object)
+      ).toThrow("The VerifiableCredential evidence must not be null or empty.");
+    });
+  });
+  describe("verifiableCredential", () => {
+    let contexts: Array<string>;
+    let evidence: Map<string, string>; Map<string, string>;
+    const twentyOfJune2023InMs = 1687269570000;
+    const thirtyMinutesInMs = 30 * 60 * 1000;
+    beforeEach(() => {
+      contexts = ["context1", "context2"];
+      evidence = new Map([
+          ["evidence-key-1", "evidence-value-1"],
+          ["evidence-key-2", "evidence-value-2"]
+      ]);
+      jest
+        .spyOn(Date.prototype, "getTime")
+        .mockReturnValueOnce(twentyOfJune2023InMs);
+    });
+
+    it("should build", () => {
+      const ttlDuration = 30;
+      expect(
+        builder
+          .subject("Kenneth Decerqueira")
+          .issuer("an-issuer-for-toy")
+          .timeToLive(ttlDuration, VerifiableCredentialBuilder.ChronoUnit.Minutes)
+          .verifiableCredentialType(["VerifiableCredential", "IdentityCheckCredential"])
+          .verifiableCredentialSubject("Kenneth Decerqueira")
+          .verifiableCredentialContext(contexts)
+          .verifiableCredentialEvidence(evidence)
+          .build()
+      ).toEqual({
+        sub: "Kenneth Decerqueira",
+        iss: "an-issuer-for-toy",
+        exp:  Math.floor(
+            twentyOfJune2023InMs + thirtyMinutesInMs
+        ),
+        vc: {
+          type: ["VerifiableCredential", "IdentityCheckCredential"],
+          credentialSubject: "Kenneth Decerqueira",
+          "@context": contexts,
+          evidence: evidence,
+        },
+      });
+    });
+    it("should build with JTI", () => {
+        const mockUUID = "0bb053c1-e78b-49a6-8df2-7182048c3b2b";
+        jest.spyOn(crypto, "randomUUID").mockReturnValueOnce(mockUUID);
+    
+        const ttlDuration = 30;
+        expect(
+          builder
+            .jti()
+            .subject("Kenneth Decerqueira")
+            .issuer("an-issuer-for-toy")
+            .timeToLive(ttlDuration, VerifiableCredentialBuilder.ChronoUnit.Minutes)
+            .verifiableCredentialType(["VerifiableCredential", "IdentityCheckCredential"])
+            .verifiableCredentialSubject("Kenneth Decerqueira")
+            .verifiableCredentialContext(contexts)
+            .verifiableCredentialEvidence(evidence)
+            .build()
+        ).toEqual({
+          jti: mockUUID,
+          sub: "Kenneth Decerqueira",
+          iss: "an-issuer-for-toy",
+          exp:  Math.floor(
+              twentyOfJune2023InMs + thirtyMinutesInMs
+          ),
+          vc: {
+            type: ["VerifiableCredential", "IdentityCheckCredential"],
+            credentialSubject: "Kenneth Decerqueira",
+            "@context": contexts,
+            evidence: evidence,
+          },
+        });
+        expect(builder.claims().jti).toBe(mockUUID);
+      });
+  
+    it("should build without context and evidence", () => {
+        const ttlDuration = 30;
+        expect(
+          builder
+            .subject("Kenneth Decerqueira")
+            .issuer("an-issuer-for-toy")
+            .timeToLive(ttlDuration, VerifiableCredentialBuilder.ChronoUnit.Minutes)
+            .verifiableCredentialType(["VerifiableCredential", "IdentityCheckCredential"])
+            .verifiableCredentialSubject("Kenneth Decerqueira")
+            .build()
+        ).toEqual({
+          sub: "Kenneth Decerqueira",
+          iss: "an-issuer-for-toy",
+          exp:  Math.floor(
+              twentyOfJune2023InMs + thirtyMinutesInMs
+          ),
+          vc: {
+            type: ["VerifiableCredential", "IdentityCheckCredential"],
+            credentialSubject: "Kenneth Decerqueira",
+          },
+        });
+        expect(builder.verifiableCredentialContext).toBeDefined;
+        expect(builder.verifiableCredentialEvidence).toBeDefined;
+    });
+    it("should build without an expiry time", () => {
+        expect(
+          builder
+            .subject("Kenneth Decerqueira")
+            .issuer("an-issuer-for-toy")
+            .verifiableCredentialType(["VerifiableCredential", "IdentityCheckCredential"])
+            .verifiableCredentialSubject("Kenneth Decerqueira")
+            .build()
+        ).toEqual({
+          sub: "Kenneth Decerqueira",
+          iss: "an-issuer-for-toy",
+          vc: {
+            type: ["VerifiableCredential", "IdentityCheckCredential"],
+            credentialSubject: "Kenneth Decerqueira",
+          },
+        });
+    });
+  });
+});

--- a/tests/utils/verifiable-credential-builder.test.ts
+++ b/tests/utils/verifiable-credential-builder.test.ts
@@ -1,22 +1,42 @@
+import {
+  GetParameterCommand,
+  ParameterType,
+  SSMClient,
+} from "@aws-sdk/client-ssm";
 import { ChronoUnit } from "../../lambdas/verifiable-credential/types/verifiable-credentials";
 import {
+  ConfigKey,
   VerifiableCredentialBuilder,
 } from "../../lambdas/verifiable-credential/verifiable-credential-builder";
-import crypto from "crypto";
+jest.mock("@aws-sdk/client-ssm", () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual("@aws-sdk/client-ssm"),
+    GetParametersCommand: jest.fn(),
+    SSMClient: {
+      prototype: {
+        send: jest.fn(),
+      },
+    },
+  };
+});
+jest.mock("crypto", () => ({
+  ...jest.requireActual("crypto"),
+  randomUUID: () => "d7c05e44-37e6-4ed4-b6d3-01af51a95f84",
+}));
+
 describe("verifiable-credential-builder.ts", () => {
   let builder: VerifiableCredentialBuilder;
-
+  const mockSSMClient = jest.mocked(SSMClient);
   beforeEach(() => {
-    builder = new VerifiableCredentialBuilder();
+    builder = new VerifiableCredentialBuilder(mockSSMClient.prototype);
   });
 
   describe("subject", () => {
     it("should be set to a value supplied", () => {
       builder.subject("Kenneth Decerqueira");
 
-      expect(builder.claims().sub).toBe(
-        "Kenneth Decerqueira"
-      );
+      expect(builder.claims().sub).toBe("Kenneth Decerqueira");
     });
 
     it.each(["", null, undefined])("should not be '%s'", (value) => {
@@ -38,39 +58,31 @@ describe("verifiable-credential-builder.ts", () => {
     });
   });
   describe("timeToLive", () => {
-    const twentyOfJune2023InMs = 1687269570000;
-    const thirtySecondsInMs = 30 * 1000;
-    const thirtyMinutesInMs = 30 * 60 * 1000;
-    const thirtyHoursInMs = 30 * 60 * 60 * 1000;
-    const thirtyDaysInMs = 30 * 24 * 60 * 60 * 1000;
     it.each([
-      [ChronoUnit.Seconds, thirtySecondsInMs],
-      [ChronoUnit.Minutes, thirtyMinutesInMs],
-      [ChronoUnit.Hours, thirtyHoursInMs],
-      [ChronoUnit.Days, thirtyDaysInMs],
-    ])("should set expiration time in '%s'", (timeUnit, ttlDuration) => {
-      jest
-        .spyOn(Date.prototype, "getTime")
-        .mockReturnValueOnce(twentyOfJune2023InMs);
-      const expectedExpirationTime = Math.floor(
-        twentyOfJune2023InMs + ttlDuration
-      );
-      builder.timeToLive(30, timeUnit);
+      [VerifiableCredentialBuilder.ChronoUnit.Days],
+      [VerifiableCredentialBuilder.ChronoUnit.Hours],
+      [VerifiableCredentialBuilder.ChronoUnit.Minutes],
+      [VerifiableCredentialBuilder.ChronoUnit.Seconds],
+    ])("should be set to supplied value '%s'", (ttlUnit) => {
+      builder.timeToLive(30, ttlUnit);
 
-      expect(builder.claims().exp).toEqual(
-        expectedExpirationTime
+      expect(builder).toEqual(
+        expect.objectContaining({ ttl: 30, ttlUnit: ttlUnit })
       );
     });
 
     it("should throw an error for an invalid unit", () => {
       expect(() =>
         builder.timeToLive(30, "invalid" as unknown as ChronoUnit)
-      ).toThrow("Unexpected time-to-live unit encountered: invalid");
+      ).toThrow("ttlUnit must be valid");
     });
   });
   describe("verifiableCredentialType", () => {
     it("should be set to the value supplied", () => {
-      builder.verifiableCredentialType(["VerifiableCredential", "IdentityCheckCredential"]);
+      builder.verifiableCredentialType([
+        "VerifiableCredential",
+        "IdentityCheckCredential",
+      ]);
 
       expect(builder.claims().vc.type).toEqual([
         "VerifiableCredential",
@@ -78,9 +90,9 @@ describe("verifiable-credential-builder.ts", () => {
       ]);
     });
     it("should not be '%s'", () => {
-      expect(() =>
-        builder.verifiableCredentialType([])
-      ).toThrow("The VerifiableCredential type must not be null or empty.");
+      expect(() => builder.verifiableCredentialType([])).toThrow(
+        "The VerifiableCredential type must not be null or empty."
+      );
     });
   });
   describe("verifiableCredentialSubject", () => {
@@ -134,38 +146,70 @@ describe("verifiable-credential-builder.ts", () => {
   });
   describe("verifiableCredential", () => {
     let contexts: Array<string>;
-    let evidence: Map<string, string>; Map<string, string>;
+    let evidence: Map<string, string>;
     const twentyOfJune2023InMs = 1687269570000;
     const thirtyMinutesInMs = 30 * 60 * 1000;
+    let getMockSend:
+      | ((value?: string | undefined) => jest.Mock<unknown, unknown[]>)
+      | ((arg1?: string | undefined) => jest.Mock);
     beforeEach(() => {
+      process.env = {
+        ...process.env,
+        AWS_STACK_NAME: "test-stack-name",
+      };
       contexts = ["context1", "context2"];
       evidence = new Map([
-          ["evidence-key-1", "evidence-value-1"],
-          ["evidence-key-2", "evidence-value-2"]
+        ["evidence-key-1", "evidence-value-1"],
+        ["evidence-key-2", "evidence-value-2"],
       ]);
+      jest.spyOn(Date, "now").mockReturnValueOnce(twentyOfJune2023InMs);
+      getMockSend = (value?: string) => {
+        return jest.fn().mockImplementation((command) => {
+          if (command instanceof GetParameterCommand) {
+            const parameterName =
+              command.input.Name === ConfigKey.CONTAINS_UNIQUE_ID
+                ? `/di-ipv-cri-toy-api/${ConfigKey.CONTAINS_UNIQUE_ID}`
+                : ConfigKey.EXPIRY_REMOVED;
+            return Promise.resolve({
+              Parameter: {
+                Name: parameterName,
+                Type: ParameterType.STRING,
+                Value: value ? value : "false",
+              },
+            });
+          }
+        });
+      };
+      mockSSMClient.prototype.send = getMockSend();
+      builder = new VerifiableCredentialBuilder(mockSSMClient.prototype);
       jest
         .spyOn(Date.prototype, "getTime")
         .mockReturnValueOnce(twentyOfJune2023InMs);
     });
-
-    it("should build", () => {
+    afterEach(() => jest.clearAllMocks());
+    it("should build", async () => {
       const ttlDuration = 30;
-      expect(
+      await expect(
         builder
           .subject("Kenneth Decerqueira")
           .issuer("an-issuer-for-toy")
-          .timeToLive(ttlDuration, VerifiableCredentialBuilder.ChronoUnit.Minutes)
-          .verifiableCredentialType(["VerifiableCredential", "IdentityCheckCredential"])
+          .timeToLive(
+            ttlDuration,
+            VerifiableCredentialBuilder.ChronoUnit.Minutes
+          )
+          .verifiableCredentialType([
+            "VerifiableCredential",
+            "IdentityCheckCredential",
+          ])
           .verifiableCredentialSubject("Kenneth Decerqueira")
           .verifiableCredentialContext(contexts)
           .verifiableCredentialEvidence(evidence)
           .build()
-      ).toEqual({
+      ).resolves.toEqual({
         sub: "Kenneth Decerqueira",
         iss: "an-issuer-for-toy",
-        exp:  Math.floor(
-            twentyOfJune2023InMs + thirtyMinutesInMs
-        ),
+        nbf: Math.floor(twentyOfJune2023InMs / 1000),
+        exp: Math.floor(twentyOfJune2023InMs + thirtyMinutesInMs),
         vc: {
           type: ["VerifiableCredential", "IdentityCheckCredential"],
           credentialSubject: "Kenneth Decerqueira",
@@ -174,79 +218,95 @@ describe("verifiable-credential-builder.ts", () => {
         },
       });
     });
-    it("should build with JTI", () => {
-        const mockUUID = "0bb053c1-e78b-49a6-8df2-7182048c3b2b";
-        jest.spyOn(crypto, "randomUUID").mockReturnValueOnce(mockUUID);
-    
-        const ttlDuration = 30;
-        expect(
-          builder
-            .jti()
-            .subject("Kenneth Decerqueira")
-            .issuer("an-issuer-for-toy")
-            .timeToLive(ttlDuration, VerifiableCredentialBuilder.ChronoUnit.Minutes)
-            .verifiableCredentialType(["VerifiableCredential", "IdentityCheckCredential"])
-            .verifiableCredentialSubject("Kenneth Decerqueira")
-            .verifiableCredentialContext(contexts)
-            .verifiableCredentialEvidence(evidence)
-            .build()
-        ).toEqual({
-          jti: mockUUID,
-          sub: "Kenneth Decerqueira",
-          iss: "an-issuer-for-toy",
-          exp:  Math.floor(
-              twentyOfJune2023InMs + thirtyMinutesInMs
-          ),
-          vc: {
-            type: ["VerifiableCredential", "IdentityCheckCredential"],
-            credentialSubject: "Kenneth Decerqueira",
-            "@context": contexts,
-            evidence: evidence,
-          },
-        });
-        expect(builder.claims().jti).toBe(mockUUID);
+    it("should build with JTI", async () => {
+      mockSSMClient.prototype.send = getMockSend("true");
+      const ttlDuration = 30;
+      await expect(
+        builder
+          .subject("Kenneth Decerqueira")
+          .issuer("an-issuer-for-toy")
+          .timeToLive(
+            ttlDuration,
+            VerifiableCredentialBuilder.ChronoUnit.Minutes
+          )
+          .verifiableCredentialType([
+            "VerifiableCredential",
+            "IdentityCheckCredential",
+          ])
+          .verifiableCredentialSubject("Kenneth Decerqueira")
+          .verifiableCredentialContext(contexts)
+          .verifiableCredentialEvidence(evidence)
+          .build()
+      ).resolves.toEqual({
+        jti: "urn:uuid:d7c05e44-37e6-4ed4-b6d3-01af51a95f84",
+        sub: "Kenneth Decerqueira",
+        iss: "an-issuer-for-toy",
+        nbf: Math.floor(twentyOfJune2023InMs / 1000),
+        vc: {
+          type: ["VerifiableCredential", "IdentityCheckCredential"],
+          credentialSubject: "Kenneth Decerqueira",
+          "@context": contexts,
+          evidence: evidence,
+        },
       });
-  
-    it("should build without context and evidence", () => {
-        const ttlDuration = 30;
-        expect(
-          builder
-            .subject("Kenneth Decerqueira")
-            .issuer("an-issuer-for-toy")
-            .timeToLive(ttlDuration, VerifiableCredentialBuilder.ChronoUnit.Minutes)
-            .verifiableCredentialType(["VerifiableCredential", "IdentityCheckCredential"])
-            .verifiableCredentialSubject("Kenneth Decerqueira")
-            .build()
-        ).toEqual({
-          sub: "Kenneth Decerqueira",
-          iss: "an-issuer-for-toy",
-          exp:  Math.floor(
-              twentyOfJune2023InMs + thirtyMinutesInMs
-          ),
-          vc: {
-            type: ["VerifiableCredential", "IdentityCheckCredential"],
-            credentialSubject: "Kenneth Decerqueira",
-          },
-        });
-        expect(builder.verifiableCredentialContext).toBeDefined;
-        expect(builder.verifiableCredentialEvidence).toBeDefined;
     });
-    it("should build without an expiry time", () => {
-        expect(
-          builder
-            .subject("Kenneth Decerqueira")
-            .issuer("an-issuer-for-toy")
-            .verifiableCredentialType(["VerifiableCredential", "IdentityCheckCredential"])
-            .verifiableCredentialSubject("Kenneth Decerqueira")
-            .build()
-        ).toEqual({
-          sub: "Kenneth Decerqueira",
-          iss: "an-issuer-for-toy",
-          vc: {
-            type: ["VerifiableCredential", "IdentityCheckCredential"],
-            credentialSubject: "Kenneth Decerqueira",
-          },
-        });
+
+    it("should build without context and evidence", async () => {
+      const ttlDuration = 30;
+      await expect(
+        builder
+          .subject("Kenneth Decerqueira")
+          .issuer("an-issuer-for-toy")
+          .timeToLive(
+            ttlDuration,
+            VerifiableCredentialBuilder.ChronoUnit.Minutes
+          )
+          .verifiableCredentialType([
+            "VerifiableCredential",
+            "IdentityCheckCredential",
+          ])
+          .verifiableCredentialSubject("Kenneth Decerqueira")
+          .build()
+      ).resolves.toEqual({
+        sub: "Kenneth Decerqueira",
+        iss: "an-issuer-for-toy",
+        nbf: Math.floor(twentyOfJune2023InMs / 1000),
+        exp: Math.floor(twentyOfJune2023InMs + thirtyMinutesInMs),
+        vc: {
+          type: ["VerifiableCredential", "IdentityCheckCredential"],
+          credentialSubject: "Kenneth Decerqueira",
+        },
+      });
+      expect(builder.verifiableCredentialContext).toBeDefined;
+      expect(builder.verifiableCredentialEvidence).toBeDefined;
+    });
+    it("should build without an expiry time", async () => {
+      mockSSMClient.prototype.send = getMockSend("true");
+      const ttlDuration = 30;
+      await expect(
+        builder
+          .subject("Kenneth Decerqueira")
+          .issuer("an-issuer-for-toy")
+          .timeToLive(
+            ttlDuration,
+            VerifiableCredentialBuilder.ChronoUnit.Minutes
+          )
+          .verifiableCredentialType([
+            "VerifiableCredential",
+            "IdentityCheckCredential",
+          ])
+          .verifiableCredentialSubject("Kenneth Decerqueira")
+          .build()
+      ).resolves.toEqual({
+        jti: "urn:uuid:d7c05e44-37e6-4ed4-b6d3-01af51a95f84",
+        sub: "Kenneth Decerqueira",
+        iss: "an-issuer-for-toy",
+        nbf: Math.floor(twentyOfJune2023InMs / 1000),
+        vc: {
+          type: ["VerifiableCredential", "IdentityCheckCredential"],
+          credentialSubject: "Kenneth Decerqueira",
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
## Proposed changes

This PR introduces a typescript util class to build the verifiable credential structure, it is in the same spirit as the one in [common-lib](https://github.com/alphagov/di-ipv-cri-lib/blob/main/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java)
It is currently not a 100%, but is good enough, for instance it currently requires the issuer to be set, whereas the common-lib uses the value from config, this would be addressed in a subsequent PR

It uses the same builder pattern

```
        builder
          .subject("Kenneth Decerqueira")
          .issuer("an-issuer-for-toy")
          .timeToLive(
            ttlDuration,
            VerifiableCredentialBuilder.ChronoUnit.Minutes
          )
          .verifiableCredentialType([
            "VerifiableCredential",
            "IdentityCheckCredential",
          ])
          .verifiableCredentialSubject("Kenneth Decerqueira")
          .verifiableCredentialContext(contexts)
          .verifiableCredentialEvidence(evidence)
          .build()
```

### What changed

Added verifiable credential structure

### Why did it change

This would be used in subsequent PR
