### PR TITLE
OJ-1657 add urls and fetch error handling

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -86,8 +86,8 @@ Globals:
         - !ImportValue cri-vpc-AWSServicesEndpointSecurityGroupId
       SubnetIds:
         [
-          !ImportValue cri-vpc-PrivateSubnetIdA,
-          !ImportValue cri-vpc-PrivateSubnetIdB,
+          !ImportValue cri-vpc-ProtectedSubnetIdA,
+          !ImportValue cri-vpc-ProtectedSubnetIdB,
         ]
     PermissionsBoundary: !If
       - UsePermissionsBoundary
@@ -149,6 +149,12 @@ Mappings:
       staging: MONTHS
       integration: MONTHS
       production: MONTHS
+
+  ToyApiUrls:
+    Environment:
+      dev: "https://36mwex8dg3.execute-api.eu-west-2.amazonaws.com/dev"
+      build: "https://36mwex8dg3.execute-api.eu-west-2.amazonaws.com/dev" # to update when the stub is deployed to build
+      staging: "https://36mwex8dg3.execute-api.eu-west-2.amazonaws.com/dev" # to update when the stub is deployed to staging
 
 Resources:
   PublicToyApi:
@@ -425,7 +431,7 @@ Resources:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-favourite"
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
-          TOY_API_URL: "third/party/stub/url"
+          TOY_API_URL: !FindInMap [ToyApiUrls, Environment, !Ref Environment]
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess

--- a/lambdas/favourite/src/favourite-handler.ts
+++ b/lambdas/favourite/src/favourite-handler.ts
@@ -89,12 +89,17 @@ export class FavouriteLambda implements LambdaInterface {
 
   private async callExternalToy(toy: string): Promise<Response> {
     if (!TOY_API_URL) {
-      throw new Error("Missing environment variable: TOY_API_URL");
+      throw new GenericServerError("Missing environment variable: TOY_API_URL");
     }
     logger.info("Calling external toy API");
-    return fetch(TOY_API_URL + "/" + toy, {
-      method: "GET",
-    });
+    try {
+      const response = await fetch(TOY_API_URL + "/" + toy, {
+        method: "GET",
+      });
+      return response;
+    } catch (error) {
+      throw new GenericServerError("Error when calling toy API: " + error);
+    }
   }
 
   private async updateContextAndSendAuditEvent(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,7 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["jest", "node", "aws-lambda"],
     "outDir": "./build/",
-    "noImplicitAny": true,
-    "lib": ["DOM"]
+    "noImplicitAny": true
   },
   "exclude": ["node_modules"],
   "include": ["./lambdas/", "./tests/"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["jest", "node", "aws-lambda"],
     "outDir": "./build/",
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": ["DOM"]
   },
   "exclude": ["node_modules"],
   "include": ["./lambdas/", "./tests/"]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Added toy URLs to template - as toy imposter stub isn't deployed to build or staging all of them are the dev stub
- Added error handling to the fetch request for better visibility
- Put the lambdas in a protected subnet to allow for them to call the api gateway

### Why did it change

Necessary changes in order for the lambda to successfully call the imposter stub
Better error handling is good practice

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1657](https://govukverify.atlassian.net/browse/OJ-1657)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1657]: https://govukverify.atlassian.net/browse/OJ-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ