### PR TITLE
BAU: specify output directory for built artefacts

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yaml
+++ b/.github/workflows/post-merge-deploy-to-dev.yaml
@@ -25,21 +25,23 @@ jobs:
         with:
           version: 1.74.0
 
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/template.yaml
+
+      - name: SAM build
+        run: |
+          mkdir out
+          sam build -t infrastructure/lambda/template.yaml -b out/
+
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: SAM Validate
-        run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/template.yaml
-
-      - name: SAM build
-        run: sam build --region ${{ env.AWS_REGION }} -t infrastructure/template.yaml
-
       - name: Deploy SAM app
         uses: alphagov/di-devplatform-upload-action@v3.2
         with:
           artifact-bucket-name: "${{ secrets.DEV_ARTIFACT_SOURCE_BUCKET_NAME }}"
           signing-profile-name: "${{ secrets.DEV_SIGNING_PROFILE_NAME }}"
-          template-file: infrastructure/template.yaml
+          working-directory: ./out

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -24,21 +24,23 @@ jobs:
         with:
           version: 1.74.0
 
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/template.yaml
+
+      - name: SAM build
+        run: |
+          mkdir out
+          sam build -t infrastructure/lambda/template.yaml -b out/
+
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.BUILD_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: SAM Validate
-        run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/template.yaml
-
-      - name: SAM build
-        run: sam build --region ${{ env.AWS_REGION }} -t infrastructure/template.yaml
-
       - name: Deploy SAM app
         uses: alphagov/di-devplatform-upload-action@v3.2
         with:
           artifact-bucket-name: "${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}"
           signing-profile-name: "${{ secrets.SIGNING_PROFILE_NAME }}"
-          template-file: infrastructure/template.yaml
+          working-directory: ./out


### PR DESCRIPTION
## Proposed changes

Specify out directory, where built artifacts are located

### What changed

Esbuild artifacts couldn't be found, so a directory needs to be specified

### Why did it change

previous PR didn't work see https://github.com/alphagov/di-ipv-cri-toy-api/pull/32

