### PR TITLE
OJ-1718 Add favourite step function endpoint

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -149,6 +149,63 @@ paths:
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
 
+  /favourite-step-function:
+    post:
+      summary: "IP address of the client."
+      parameters:
+        - $ref: "#/components/parameters/SessionHeader"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Favourite"
+            examples:
+              jigsaw-puzzle:
+                summary: "Example body to receive a HTTP 200 response"
+                value:
+                  toy: "jigsaw-puzzle"
+              tennis-bat:
+                summary: "Example body to receive a HTTP 400 response"
+                value:
+                  toy: "tennis-bat"
+              football:
+                summary: "Example body to receive a HTTP 500 response"
+                value:
+                  toy: "football"
+        required: true
+      responses:
+        "404":
+          description: "404 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "200":
+          description: "200 response"
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        passthroughBehavior: "when_no_templates"
+        type: "aws"
+        credentials: arn:aws:iam::700803526010:role/SarahTestApiStepFunctionRole
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:states:action/StartExecution
+        responses:
+          default:
+            statusCode: "200"
+        requestTemplates:
+          application/json: |
+            {
+              "input": "{\"toy\": \"$util.parseJson($input.json('$.toy'))\",\"sessionId\": \"$input.params('session-id')\"}",
+              "stateMachineArn": "arn:aws:states:eu-west-2:700803526010:stateMachine:ToyFavouriteStepFunction"
+            }
+
 components:
   parameters:
     SessionHeader:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added an endpoint which directs to our manually created step function - https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn:aws:states:eu-west-2:700803526010:stateMachine:ToyFavouriteStepFunction

### Why did it change

Allows us to invoke the step function from the front end

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1718](https://govukverify.atlassian.net/browse/OJ-1718)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed



[OJ-1718]: https://govukverify.atlassian.net/browse/OJ-1718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ