### PR TITLE
OJ-1765: add missing month year time units

### DIFF
--- a/lambdas/common/utils/time-units.ts
+++ b/lambdas/common/utils/time-units.ts
@@ -1,15 +1,37 @@
-export enum TimeUnit {
-  Seconds = "seconds",
-  Minutes = "minutes",
-  Hours = "hours",
-  Days = "days",
-}
-export function getTimeUnitValue(value?: string): TimeUnit {
-  const unitKey = Object.keys(TimeUnit).find(
-    (key) => TimeUnit[key as keyof typeof TimeUnit] === value?.toLowerCase()
-  );
-  if (unitKey) {
-    return TimeUnit[unitKey as keyof typeof TimeUnit];
-  }
-  throw new Error(`Invalid value: ${value}`);
+export class TimeUnit {
+  public static readonly Unit = {
+    Seconds: "seconds",
+    Minutes: "minutes",
+    Hours: "hours",
+    Days: "days",
+    Months: "months",
+    Years: "years",
+  };
+
+  public static convert = (unit?: string): number => {
+    switch (unit) {
+      case TimeUnit.Unit.Seconds:
+        return 1000;
+      case TimeUnit.Unit.Minutes:
+        return 1000 * 60;
+      case TimeUnit.Unit.Hours:
+        return 1000 * 60 * 60;
+      case TimeUnit.Unit.Days:
+        return 1000 * 60 * 60 * 24;
+      default:
+        throw new Error(`Unexpected time-to-live unit encountered: ${unit}`);
+    }
+  };
+
+  public static getValue = (value?: string) => {
+    const unitKey = Object.keys(TimeUnit.Unit).find(
+      (key) =>
+        TimeUnit.Unit[key as keyof typeof TimeUnit.Unit] ===
+        value?.toLowerCase()
+    );
+    if (unitKey) {
+      return TimeUnit.Unit[unitKey as keyof typeof TimeUnit.Unit];
+    }
+    throw new Error(`ttlUnit must be valid: ${value}`);
+  };
 }

--- a/lambdas/issue-credential/src/issue-credential-handler.ts
+++ b/lambdas/issue-credential/src/issue-credential-handler.ts
@@ -27,7 +27,6 @@ import { AuditEventType } from "../../types/audit-event";
 import { SQSClient } from "@aws-sdk/client-sqs";
 import { SessionItem } from "../../types/session-item";
 import { SessionService } from "../../services/session-service";
-import { getTimeUnitValue } from "../../common/utils/time-units";
 import { PersonIdentity } from "../../types/person-identity";
 import getSessionByIdMiddleware from "../../middlewares/session/get-session-by-id-middleware";
 import { JwtSigner } from "../../jwt-signer/jwt-signer";
@@ -57,7 +56,6 @@ export class IssueCredentialLambda implements LambdaInterface {
     logger.info("Toy issue-credential lambda triggered");
 
     const ttlDuration = (await getMaxJwtTl()).Value;
-    const ttlUnit = getTimeUnitValue((await getJwtTlUnit()).Value);
     const toyBody = event.body as unknown as ToyItem;
     const sessionItem = event.body as unknown as SessionItem;
 
@@ -80,7 +78,7 @@ export class IssueCredentialLambda implements LambdaInterface {
 
     const vcClaimSet = await builder
       .subject(toyBody.toy)
-      .timeToLive(ttlUnit, Number(ttlDuration))
+      .timeToLive((await getJwtTlUnit()).Value, Number(ttlDuration))
       .verifiableCredentialType("ToyCredential")
       .verifiableCredentialContext([
         VC_CONTEXT.DI_CONTEXT,

--- a/tests/utils/time-units.test.ts
+++ b/tests/utils/time-units.test.ts
@@ -1,0 +1,35 @@
+import { TimeUnit } from "../../lambdas/common/utils/time-units";
+
+describe("TimeUnit", () => {
+  describe("convertTo", () => {
+    it("should return the correct conversion for each unit", () => {
+      expect(TimeUnit.convert(TimeUnit.Unit.Seconds)).toBe(1000);
+      expect(TimeUnit.convert(TimeUnit.Unit.Minutes)).toBe(1000 * 60);
+      expect(TimeUnit.convert(TimeUnit.Unit.Hours)).toBe(1000 * 60 * 60);
+      expect(TimeUnit.convert(TimeUnit.Unit.Days)).toBe(1000 * 60 * 60 * 24);
+    });
+
+    it("should throw an error for an unexpected unit", () => {
+      expect(() => TimeUnit.convert("invalid_unit")).toThrowError(
+        "Unexpected time-to-live unit encountered: invalid_unit"
+      );
+    });
+  });
+
+  describe("getValue", () => {
+    it("should return the correct value for each unit", () => {
+      expect(TimeUnit.getValue("seconds")).toBe(TimeUnit.Unit.Seconds);
+      expect(TimeUnit.getValue("minutes")).toBe(TimeUnit.Unit.Minutes);
+      expect(TimeUnit.getValue("hours")).toBe(TimeUnit.Unit.Hours);
+      expect(TimeUnit.getValue("days")).toBe(TimeUnit.Unit.Days);
+      expect(TimeUnit.getValue("months")).toBe(TimeUnit.Unit.Months);
+      expect(TimeUnit.getValue("years")).toBe(TimeUnit.Unit.Years);
+    });
+
+    it("should throw an error for an invalid unit", () => {
+      expect(() => TimeUnit.getValue("invalid_unit")).toThrowError(
+        "ttlUnit must be valid: invalid_unit"
+      );
+    });
+  });
+});

--- a/tests/verifiable-credential/verifiable-credential-builder.test.ts
+++ b/tests/verifiable-credential/verifiable-credential-builder.test.ts
@@ -1,9 +1,6 @@
 import { ParameterType, SSMClient } from "@aws-sdk/client-ssm";
 import { VerifiableCredentialBuilder } from "../../lambdas/verifiable-credential/verifiable-credential-builder";
-import {
-  TimeUnit,
-  getTimeUnitValue,
-} from "../../lambdas/common/utils/time-units";
+import { TimeUnit } from "../../lambdas/common/utils/time-units";
 jest.mock("@aws-sdk/client-ssm", () => ({
   __esModule: true,
   ...jest.requireActual("@aws-sdk/client-ssm"),
@@ -53,10 +50,12 @@ describe("verifiable-credential-builder.ts", () => {
   });
   describe("timeToLive", () => {
     it.each([
-      [TimeUnit.Days],
-      [TimeUnit.Hours],
-      [TimeUnit.Minutes],
-      [TimeUnit.Seconds],
+      [TimeUnit.Unit.Years],
+      [TimeUnit.Unit.Months],
+      [TimeUnit.Unit.Days],
+      [TimeUnit.Unit.Hours],
+      [TimeUnit.Unit.Minutes],
+      [TimeUnit.Unit.Seconds],
     ])("should be set to supplied value '%s'", (ttlUnit) => {
       builder.timeToLive(ttlUnit, 30);
 
@@ -65,10 +64,10 @@ describe("verifiable-credential-builder.ts", () => {
       );
     });
 
-    it.each(["DAYS", "HOURS", "MINUTES", "SECONDS"])(
+    it.each(["YEARS", "MONTHS", "DAYS", "HOURS", "MINUTES", "SECONDS"])(
       "should be set to supplied value '%s'",
       (ttlUnit) => {
-        builder.timeToLive(getTimeUnitValue(ttlUnit), 30);
+        builder.timeToLive(ttlUnit, 30);
 
         expect(builder).toEqual(
           expect.objectContaining({ ttl: 30, ttlUnit: builder["ttlUnit"] })
@@ -76,9 +75,9 @@ describe("verifiable-credential-builder.ts", () => {
       }
     );
     it("should throw an error for an invalid unit", () => {
-      expect(() =>
-        builder.timeToLive("invalid" as unknown as TimeUnit, 30)
-      ).toThrow("ttlUnit must be valid");
+      expect(() => builder.timeToLive("invalid", 30)).toThrow(
+        `ttlUnit must be valid: invalid`
+      );
     });
   });
   describe("verifiableCredentialType", () => {
@@ -200,7 +199,7 @@ describe("verifiable-credential-builder.ts", () => {
         await expect(
           builder
             .subject("Kenneth Decerqueira")
-            .timeToLive(TimeUnit.Minutes, ttlDuration)
+            .timeToLive(TimeUnit.Unit.Minutes, ttlDuration)
             .verifiableCredentialType("ToyCredential")
             .verifiableCredentialSubject({
               somesubject: {
@@ -234,7 +233,7 @@ describe("verifiable-credential-builder.ts", () => {
           builder
             .subject("Kenneth Decerqueira")
             .issuer("an-issuer-for-toy")
-            .timeToLive(TimeUnit.Minutes, ttlDuration)
+            .timeToLive(TimeUnit.Unit.Minutes, ttlDuration)
             .verifiableCredentialType("ToyCredential")
             .verifiableCredentialSubject("Kenneth Decerqueira")
             .build()
@@ -284,7 +283,7 @@ describe("verifiable-credential-builder.ts", () => {
           builder
             .subject("Kenneth Decerqueira")
             .issuer("an-issuer-for-toy")
-            .timeToLive(TimeUnit.Minutes, ttlDuration)
+            .timeToLive(TimeUnit.Unit.Minutes, ttlDuration)
             .verifiableCredentialType("ToyCredential")
             .verifiableCredentialSubject({
               someothersubject: {
@@ -331,7 +330,7 @@ describe("verifiable-credential-builder.ts", () => {
         await expect(
           builder
             .subject("Kenneth Decerqueira")
-            .timeToLive(TimeUnit.Minutes, ttlDuration)
+            .timeToLive(TimeUnit.Unit.Minutes, ttlDuration)
             .verifiableCredentialType("ToyCredential")
             .verifiableCredentialSubject({
               somesubject: {
@@ -366,7 +365,7 @@ describe("verifiable-credential-builder.ts", () => {
           builder
             .subject("Kenneth Decerqueira")
             .issuer("an-issuer-for-toy")
-            .timeToLive(TimeUnit.Minutes, ttlDuration)
+            .timeToLive(TimeUnit.Unit.Minutes, ttlDuration)
             .verifiableCredentialType("ToyCredential")
             .verifiableCredentialSubject("Kenneth Decerqueira")
             .build()


### PR DESCRIPTION
## Proposed changes

VC is configured in staging for months, when generating the VC using typescript the month was missing and generation failed

### What changed

Refactored TimeUnit functions into static class
Added months and years time unit

### Why did it change

Missing unit in VC generation

### Issue tracking

- [OJ-1403](https://govukverify.atlassian.net/browse/OJ-1403)
- [OJ-1765](https://govukverify.atlassian.net/browse/OJ-1765)


[OJ-1403]: https://govukverify.atlassian.net/browse/OJ-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OJ-1765]: https://govukverify.atlassian.net/browse/OJ-1765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ