### PR TITLE
BAU: import the imposter stub url

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -149,12 +149,6 @@ Mappings:
       integration: MONTHS
       production: MONTHS
 
-  ToyApiUrls:
-    Environment:
-      dev: "https://36mwex8dg3.execute-api.eu-west-2.amazonaws.com/dev"
-      build: "https://36mwex8dg3.execute-api.eu-west-2.amazonaws.com/dev" # to update when the stub is deployed to build
-      staging: "https://36mwex8dg3.execute-api.eu-west-2.amazonaws.com/dev" # to update when the stub is deployed to staging
-
 Resources:
   PublicToyApi:
     Type: AWS::Serverless::Api
@@ -513,7 +507,7 @@ Resources:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-favourite"
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
-          TOY_API_URL: !FindInMap [ToyApiUrls, Environment, !Ref Environment]
+          TOY_API_URL: !ImportValue ImposterStubApiUrl
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess


### PR DESCRIPTION
## Proposed changes

The imposter stub url is now imported from [di-third-party-stubs](https://github.com/alphagov/di-ipv-third-party-stubs/blob/main/infrastructure/new-template.yaml#L261)

