### PR TITLE
[WIP] OJ-1960: Set up SonarCloud scanning on PRs and merges

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,21 @@
+name: Code quality
+
+on:
+  push:
+    branches: [main]
+
+concurrency: code-quality
+permissions: {}
+
+jobs:
+  coverage:
+    name: Coverage
+    uses: ./.github/workflows/unit-tests.yml
+
+  sonarcloud:
+    name: Scan
+    needs: coverage
+    uses: ./.github/workflows/sonarcloud.yml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,36 @@
+name: SonarCloud
+
+on:
+  workflow_call:
+    secrets:
+      github-token: { required: true }
+      sonar-token: { required: true }
+
+concurrency:
+  group: sonarcloud-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  scan:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get coverage results
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+          path: coverage
+
+      - name: Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.github-token }}
+          SONAR_TOKEN: ${{ secrets.sonar-token }}


### PR DESCRIPTION
_[This repo in SonarCloud](https://sonarcloud.io/project/overview?id=di-ipv-cri-toy-api)_

**Add SonarCloud config and workflow**

The reusable workflow gets coverage results from the calling workflow.
Add a standalone workflow to run SonarCloud on merges to main.
Add a Check PR workflow to run SonarCloud on PRs, alongside other checks.

**Add a workflow to verify PRs**

- Make unit tests and pre-commit reusable workflows
- Use the pre-commit action from the DI GitHub Actions library
- Add jest config to use when running in GitHub Actions - this uses a CI-friendly results reporter

Add one workflow to run all checks required for a PR to pass, and use reusable workflows, which allows to:
   - define dependencies (for example, SonarCloud needs unit tests to get the coverage reports)
   - make it easier to see all failures for a PR in the UI (only one workflow needs to be opened)

<img width="639" alt="Screenshot 2023-10-10 at 14 49 53" src="https://github.com/alphagov/di-ipv-cri-toy-api/assets/3608562/bc5cd6b1-1017-4df1-811a-285f1c9734b9">

**Update jest config and commands**

- Update jest config to correctly collect coverage
- Use default config values
- Update the scripts to make coverage a separate command
- Exclude files in the build directory from jest

---

- Add permissions and concurrency to all workflows
- Apply consisitent formatting to all workflows.

**BAU: Upgrade pre-commit hooks to the latest versions**

Add a pre-commit command to package.json, so pre-commit can be easily run on-demand.

Prettier v3.0 changed the default setting for the trailing commas option. Set it to the previous default in the config file to avoid having to update all the files (this can be done at a later time).
Reference: https://prettier.io/docs/en/options.html#trailing-commas