### PR TITLE
BAU: remove always deploy on public-api

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -161,7 +161,6 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       Description: Public Toy CRI API
-      AlwaysDeploy: true
       MethodSettings:
         - LoggingLevel: INFO
           ResourcePath: "/*"


### PR DESCRIPTION
## Proposed changes

Remove always deploy flag on public-api 
 
### What changed

This was added in the [last PR](https://github.com/govuk-one-login/ipv-cri-toy-api/pull/52/commits/79ae126dc2c2efd7f0d65268c52ccf0a48b1551d)

### Why did it change

see last PR https://github.com/govuk-one-login/ipv-cri-toy-api/pull/52
### Issue tracking
