### PR TITLE
BAU: add back localdev for memorysize

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -149,6 +149,7 @@ Mappings:
   MemorySizeMapping:
     Environment:
       dev: 1024
+      localdev: 1024
       build: 3072
       staging: 2048
       integration: 2048


### PR DESCRIPTION
## Proposed changes

Add back `localdev` for memorysize 

### What changed

Was removed by https://github.com/govuk-one-login/ipv-cri-toy-api/commit/e5433c0770353bdf04f10ffc7ae8620c8e1ceb6e 

### Why did it change

A mistake, in the commit point to above
