### PR TITLE
BAU: Add localdev for Dynatrace SecretArn

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -163,7 +167,7 @@
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "8a874a3fb21250a2518578da2c545eee007741ce",
         "is_verified": false,
-        "line_number": 147
+        "line_number": 148
       }
     ],
     "tests/middleware/validate-header-bearer-token-middleware.test.ts": [
@@ -176,5 +180,5 @@
       }
     ]
   },
-  "generated_at": "2023-12-19T11:46:26Z"
+  "generated_at": "2023-12-21T09:41:18Z"
 }

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -141,6 +141,7 @@ Mappings:
   Dynatrace:
     SecretArn:
       dev: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      localdev: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       build: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       staging: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       integration: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables


### PR DESCRIPTION
Add `localdev` for Dynatrace

### What changed

Add `localdev` for Dynatrace

### Why did it change

Fixes `Template error: Unable to get mapping for Dynatrace::SecretArn::localdev` when running deploy.sh
