### PR TITLE
BAU: Disable rollback on failed deployments

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -53,6 +53,7 @@ jobs:
           cache-key: cri-toy-api
           s3-prefix: preview
           pull-repository: true
+          disable-rollback: false
           delete-failed-stack: true
           tags: |
             cri:component=ipv-cri-toy-api


### PR DESCRIPTION
We want to see the logs and resources in the AWS Console when deployments fail so we can diagnose issues.