### PR TITLE
OJ-2279: Fix deployments to dev

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -205,7 +205,7 @@ paths:
             Fn::Sub: |-
               {
                 "input": "{\"toy\": \"$util.parseJson($input.json('$.toy'))\",\"sessionId\": \"$input.params('session-id')\"}",
-                "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-favourite-state-machine"
+                "stateMachineArn": "${FavouriteStateMachine.Arn}"
               }
 
 components:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -373,7 +373,6 @@ Resources:
         PrivateApiId:
           !If [IsLocalDevEnvironment, !Ref DevOnlyToyApi, !Ref PrivateToyApi]
       Role: !GetAtt FavouriteStateMachineRole.Arn
-      Name: !Sub "${AWS::StackName}-favourite-state-machine"
       Logging:
         Destinations:
           - CloudWatchLogsLogGroup:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -322,13 +322,13 @@ Resources:
     Type: AWS::Logs::LogGroup
     Condition: IsLocalDevEnvironment
     Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${DevOnlyToyApi}-private-AccessLogs
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}/${DevOnlyToyApi}-private-AccessLogs
       RetentionInDays: 3
 
   PublicToyApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PublicToyApi}-public-AccessLogs
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}/${PublicToyApi}-public-AccessLogs
       RetentionInDays: 365
 
   PublicToyApiAccessLogGroupSubscriptionFilterCSLS:
@@ -343,7 +343,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Condition: IsNotLocalDevEnvironment
     Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-private-${PrivateToyApi}-access-logs
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}/${PrivateToyApi}-private-access-logs
       RetentionInDays: !If [IsDevEnvironment, 30, 365]
 
   PrivateToyApiAccessLogGroupSubscriptionFilterCSLS:
@@ -362,7 +362,7 @@ Resources:
   FavouriteStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "${AWS::StackName}-favourite-state-machine-log-group"
+      LogGroupName: !Sub /aws/states/${AWS::StackName}/favourite-state-machine
       RetentionInDays: 30
 
   FavouriteStateMachine:


### PR DESCRIPTION
**Don't use the stack name in state machines names**

The state machine names have a shorter length restriction that stack names, so if the stack name is too long the deployment will fail. Instead, let CloudFormation generate unique names, which by default include the stack information.

This affects dependabot which creates branches with long names that can't be deployed for testing.

**Use the common format for log group names**

Apply the format `aws/<service>/<stack name>/<resource>` used in other repos.