### PR TITLE
Fix an error with linting

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -784,7 +784,6 @@ Resources:
       OKActions:
         - !ImportValue core-infrastructure-AlarmTopic
       InsufficientDataActions: []
-      Dimensions: []
       DatapointsToAlarm: 3
       EvaluationPeriods: 3
       Threshold: 1
@@ -828,7 +827,6 @@ Resources:
       OKActions:
         - !ImportValue core-infrastructure-AlarmTopic
       InsufficientDataActions: []
-      Dimensions: []
       DatapointsToAlarm: 3
       EvaluationPeriods: 3
       Threshold: 2


### PR DESCRIPTION
'''[[E3020: Validate that when a property is specified another property should be excluded] ('Dimensions' should not be included with 'Metrics') matched 787, [E3020: Validate that when a property is specified another property should be excluded] ('Dimensions' should not be included with 'Metrics') matched 831]
Error: Linting failed. At least one linting rule was matched to the provided template.
'''

This was the error - removing empty Dimensions property is the fix
