### PR TITLE
Fix an error in the deploy check

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -50,6 +50,7 @@ jobs:
           sam-deployment-bucket: ${{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
           stack-name-prefix: preview-cri-toy-api
+          stack-name-length-limit: 50
           cache-key: cri-toy-api
           s3-prefix: preview
           pull-repository: true


### PR DESCRIPTION
The state machine was getting a longer than supported name (Max is 80 chars)
